### PR TITLE
Add composer.json to install developer-toolbar via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+  "name": "shopwareLabs/SwagProfiling",
+  "type": "shopware-frontend-plugin",
+  "description": "Adds developer-toolbar to Shopware-frontend",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "ShopwareLabs"
+    }
+  ],
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
We're installing all Shopware-plugins via composer on deployment via capistrano. As we're doing so on our local development-machines via vagrant as well I've added a `composer.json` using the `shopware-frontend-plugin`-type. Please also have a look on my [PR for composer](https://github.com/composer/installers/pull/275).
